### PR TITLE
Update ModelContextProtocol packages to 0.4.0-preview.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,12 +3,18 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dariogriffo/postg-mem</PackageProjectUrl>
-    <VersionPrefix>1.6.1</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
-    <PackageReleaseNotes>- [Bump OllamaSharp from 5.2.10 to 5.3.3](https://github.com/petabridge/memorizer-v1/pull/13)
-- [Bump `ModelContextProtocol` from 0.1.0-preview.14 to 0.3.0-preview.3](https://github.com/petabridge/memorizer-v1/pull/15)</PackageReleaseNotes>
+    <PackageReleaseNotes>**Features**
+- [Add configurable CORS support for MCP SSE endpoints](https://github.com/petabridge/memorizer-v1/pull/53) - Enables MCP clients to connect with customizable CORS policies
+- [Make embedding dimensions configurable](https://github.com/petabridge/memorizer-v1/pull/18) - Support different embedding models via `Dimensions` setting
+
+**Updates**
+- [Bump all MSFT dependencies to 9.0.9](https://github.com/petabridge/memorizer-v1/pull/54) - Updated to .NET 9 framework
+- [Bump ModelContextProtocol from 0.3.0-preview.3 to 0.3.0-preview.4](https://github.com/petabridge/memorizer-v1/pull/36) - Framework improvements and bug fixes
+- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.3 to 0.3.0-preview.4](https://github.com/petabridge/memorizer-v1/pull/39) - Framework improvements and bug fixes</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-    <PropertyGroup Label="SharedVersions">
-        <MsftVersion>9.0.9</MsftVersion>
-    </PropertyGroup>
+  <PropertyGroup Label="SharedVersions">
+    <MsftVersion>9.0.9</MsftVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="Configuration.Extensions.EnvironmentFile" Version="2.0.1" />
@@ -13,8 +13,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(MsftVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MsftVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MsftVersion)" />
-    <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.4" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.4" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.2" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.2" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="OllamaSharp" Version="5.3.6" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 1.7.0 October 9th 2025 ####
+
+**Features**
+- [Add configurable CORS support for MCP SSE endpoints](https://github.com/petabridge/memorizer-v1/pull/53) - Enables MCP clients to connect with customizable CORS policies
+- [Make embedding dimensions configurable](https://github.com/petabridge/memorizer-v1/pull/18) - Support different embedding models via `Dimensions` setting
+
+**Updates**
+- [Bump all MSFT dependencies to 9.0.9](https://github.com/petabridge/memorizer-v1/pull/54) - Updated to .NET 9 framework
+- [Bump ModelContextProtocol from 0.3.0-preview.3 to 0.3.0-preview.4](https://github.com/petabridge/memorizer-v1/pull/36) - Framework improvements and bug fixes
+- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.3 to 0.3.0-preview.4](https://github.com/petabridge/memorizer-v1/pull/39) - Framework improvements and bug fixes
+
 #### 1.6.1 July 24th 2025 ####
 
 - [Bump OllamaSharp from 5.2.10 to 5.3.3](https://github.com/petabridge/memorizer-v1/pull/13)

--- a/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
+++ b/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="ModelContextProtocol.AspNetCore" VersionOverride="0.3.0-preview.4" />
+      <PackageReference Include="ModelContextProtocol.AspNetCore" VersionOverride="0.4.0-preview.2" />
       <PackageReference Include="OllamaSharp" VersionOverride="5.3.6" />
         <ProjectReference Include="..\Memorizer\Memorizer.csproj" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
Updates ModelContextProtocol packages from 0.3.0-preview.4 to 0.4.0-preview.2 to resolve MCP client connection issues.

## Changes
- Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2
- Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2
- Adds new dependency: Microsoft.Extensions.AI.Abstractions 9.9.1

## Motivation
Claude Code was unable to connect to the Memorizer MCP server at http://old-gpu:5000/. Updating to the latest MCP packages should resolve protocol compatibility issues.

## Test Plan
- [x] Build succeeds
- [ ] Integration tests pass
- [ ] Verify MCP client connectivity after deployment